### PR TITLE
feat: WIP: file-sharing for web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,6 +2507,7 @@ dependencies = [
  "futures",
  "jiri-core",
  "multiaddr",
+ "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -5282,6 +5283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
 dependencies = [
  "getrandom 0.2.9",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 
 [features]
-default = ["libp2p/dns", "libp2p/mdns", "libp2p/kad", "libp2p/tcp", "libp2p/websocket", "libp2p/floodsub", "libp2p/gossipsub", "libp2p/tokio"]
+default = ["libp2p/dns", "libp2p/mdns", "libp2p/tcp", "libp2p/websocket", "libp2p/gossipsub", "libp2p/tokio"]
 web = ["dep:libp2p-websys-transport", "libp2p/wasm-bindgen"]
 
 [dependencies]
@@ -13,7 +13,7 @@ async-trait = "0.1"
 bytes = "1.4.0"
 env_logger = "0.10"
 futures = "0.3.28"
-libp2p = { version = "0.51.3", default-features = false, features = ["noise", "macros", "yamux", "floodsub", "request-response"] }
+libp2p = { version = "0.51.3", default-features = false, features = ["kad", "noise", "macros", "yamux", "floodsub", "request-response"] }
 libp2p-websys-transport = { version = "0.1.5", optional = true }
 log = "0.4.17"
 multiaddr = { version = "0.17.1" }

--- a/core/src/p2p.rs
+++ b/core/src/p2p.rs
@@ -346,6 +346,12 @@ impl Core {
         key: Vec<u8>,
         providers: HashSet<PeerId>,
     ) -> Result<(), Box<dyn Error>> {
+        log::debug!(
+            "get-providers is done. key:{}, providers:{:?}",
+            String::from_utf8(key.clone())?,
+            providers
+        );
+
         if !self.pending_get_providers.remove(&id) {
             log::warn!("get_providers_progressed event has been already handled. skipping this duplicate event...");
             return Ok(());
@@ -373,6 +379,7 @@ impl Core {
         });
 
         // Wait until at least one command::Command::RequestFile sending is done
+        log::debug!("Wait until at least one command::Command::RequestFile sending is done");
         futures::future::select_ok(requests)
             .await
             .map_err(|_| "Failed to send command::Command::RequestFile to any peers")?;
@@ -469,11 +476,13 @@ impl Core {
             }
             command::Command::RequestFile { file_name, peer } => {
                 //TODO: This doesn't work if the peer is in browser.
+                log::debug!("Sending a request to {:?} for {}", peer, file_name.clone());
                 let request_id = self
                     .swarm
                     .behaviour_mut()
                     .request_response
                     .send_request(&peer, FileRequest(file_name.clone()));
+                log::debug!("Sent request successfully");
 
                 if let Some(request_ids) = self.pending_request_file.get_mut(&file_name) {
                     request_ids.insert(request_id);

--- a/core/src/p2p/behaviour.rs
+++ b/core/src/p2p/behaviour.rs
@@ -1,26 +1,19 @@
-use std::error::Error;
-
+use super::file_exchange::{FileExchangeCodec, FileExchangeProtocol};
 use libp2p::{
     floodsub::{self, Floodsub},
     identity,
+    kad::{store::MemoryStore, Kademlia},
+    request_response::{self, ProtocolSupport},
     swarm::{keep_alive, NetworkBehaviour},
 };
+use std::{error::Error, iter};
 
 #[cfg(not(feature = "web"))]
-use super::file_exchange::{FileExchangeCodec, FileExchangeProtocol};
-#[cfg(not(feature = "web"))]
-use libp2p::{
-    gossipsub,
-    kad::{store::MemoryStore, Kademlia},
-    mdns,
-    request_response::{self, ProtocolSupport},
-    PeerId,
-};
+use libp2p::{gossipsub, mdns, PeerId};
 #[cfg(not(feature = "web"))]
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
-    iter,
     time::Duration,
 };
 
@@ -28,15 +21,13 @@ use std::{
 pub struct JiriBehaviour {
     pub keep_alive: keep_alive::Behaviour,
     pub floodsub: Floodsub,
+    pub kademlia: Kademlia<MemoryStore>,
+    pub request_response: request_response::Behaviour<FileExchangeCodec>,
 
     #[cfg(not(feature = "web"))]
     pub gossipsub: gossipsub::Behaviour,
     #[cfg(not(feature = "web"))]
     pub mdns: mdns::tokio::Behaviour,
-    #[cfg(not(feature = "web"))]
-    pub kademlia: Kademlia<MemoryStore>,
-    #[cfg(not(feature = "web"))]
-    pub request_response: request_response::Behaviour<FileExchangeCodec>,
 }
 
 impl JiriBehaviour {
@@ -51,21 +42,22 @@ impl JiriBehaviour {
         floodsub.subscribe(floodsub_topic);
 
         #[cfg(not(feature = "web"))]
-        let (gossipsub, mdns, kademlia, request_response) =
-            JiriBehaviour::new_standalone(id_keys, peer_id, gossipsub_topic)?;
+        let (gossipsub, mdns) = JiriBehaviour::new_standalone(id_keys, peer_id, gossipsub_topic)?;
 
         Ok(Self {
             keep_alive: keep_alive::Behaviour::default(),
             floodsub,
+            kademlia: Kademlia::new(peer_id, MemoryStore::new(peer_id)),
+            request_response: request_response::Behaviour::new(
+                FileExchangeCodec(),
+                iter::once((FileExchangeProtocol(), ProtocolSupport::Full)),
+                Default::default(),
+            ),
 
             #[cfg(not(feature = "web"))]
             gossipsub,
             #[cfg(not(feature = "web"))]
             mdns,
-            #[cfg(not(feature = "web"))]
-            kademlia,
-            #[cfg(not(feature = "web"))]
-            request_response,
         })
     }
 
@@ -74,15 +66,7 @@ impl JiriBehaviour {
         id_keys: identity::Keypair,
         peer_id: PeerId,
         gossipsub_topic: &gossipsub::IdentTopic,
-    ) -> Result<
-        (
-            gossipsub::Behaviour,
-            mdns::tokio::Behaviour,
-            Kademlia<MemoryStore>,
-            request_response::Behaviour<FileExchangeCodec>,
-        ),
-        Box<dyn Error>,
-    > {
+    ) -> Result<(gossipsub::Behaviour, mdns::tokio::Behaviour), Box<dyn Error>> {
         let mut gossipsub = gossipsub::Behaviour::new(
             gossipsub::MessageAuthenticity::Signed(id_keys),
             gossipsub::ConfigBuilder::default()
@@ -100,12 +84,6 @@ impl JiriBehaviour {
         Ok((
             gossipsub,
             mdns::tokio::Behaviour::new(mdns::Config::default(), peer_id)?,
-            Kademlia::new(peer_id, MemoryStore::new(peer_id)),
-            request_response::Behaviour::new(
-                FileExchangeCodec(),
-                iter::once((FileExchangeProtocol(), ProtocolSupport::Full)),
-                Default::default(),
-            ),
         ))
     }
 }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -14,3 +14,4 @@ jiri-core = { path = "../core", default-features = false, features = ["web"] }
 multiaddr = "0.17.1"
 futures = "0.3.28"
 console_error_panic_hook = "0.1.7"
+uuid = { version = "1.3.2", features = ["v4", "fast-rng"] }

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -188,6 +188,16 @@ impl eframe::App for MainApp {
                     }
                 }
 
+                if self.connected {
+                    if ui.button("Chat").clicked() {
+                        self.send_chat();
+                    }
+                } else {
+                    if ui.button("Connect").clicked() {
+                        self.send_dial();
+                    }
+                }
+
                 let file_text_resp = ui.text_edit_singleline(&mut self.file);
                 if file_text_resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
                     if self.connected {
@@ -197,13 +207,9 @@ impl eframe::App for MainApp {
                     }
                 }
 
-                if self.connected {
-                    if ui.button("Chat").clicked() {
-                        self.send_chat();
-                    }
-                } else {
-                    if ui.button("Connect").clicked() {
-                        self.send_dial();
+                if ui.button("Send File").clicked() {
+                    if self.connected {
+                        self.send_file();
                     }
                 }
             });

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -118,6 +118,7 @@ impl MainApp {
                 console_log!("Error from oneshot_rx: {e:?}");
                 return;
             }
+            console_log!("Start-providing is done: file_name: {}", file_name);
 
             let _ = command_tx
                 .send(command::Command::SendMessage(message::Message::FileAd(


### PR DESCRIPTION
I implemented this based on the file-sharing code that I implemented for the WebSocket API of the `jiri-standalone`. But, when the `jiri-standalone` tries to send a `FileRequest` to the web via request-response protocol, the following error occurs:
```
[2023-05-03T11:35:21Z INFO  jiri_core::p2p] Sending a request to PeerId("12D3KooWEcodQSPbhaTTF9v9RSmQUTf4UY99qCcYT1SbTseE8EsT") for 6990c425-f1cf-4130-9027-8d93b9074974
[2023-05-03T11:35:21Z INFO  jiri_core::p2p] Sent request successfully
[2023-05-03T11:35:21Z DEBUG yamux::connection] 3340b205: new outbound (Stream 3340b205/6) of (Connection 3340b205 Server (streams 2))
[2023-05-03T11:35:21Z DEBUG multistream_select::dialer_select] Dialer: Proposed protocol: /jiri-file-exchange/1
[2023-05-03T11:35:21Z DEBUG multistream_select::dialer_select] Dialer: Received confirmation for protocol: /jiri-file-exchange/1
[2023-05-03T11:35:21Z DEBUG libp2p_core::upgrade::apply] Failed to upgrade outbound stream to /jiri-file-exchange/1
[2023-05-03T11:35:21Z DEBUG libp2p_swarm] Connection closed with error Handler(Left(Left(Left(Right(Upgrade(Apply(Kind(UnexpectedEof)))))))): Connected { endpoint: Listener { local_addr: "/ip4/172.30.1.25/tcp/8081/ws", send_back_addr: "/ip4/172.30.1.25/tcp/57019/ws" }, peer_id: PeerId("12D3KooWEcodQSPbhaTTF9v9RSmQUTf4UY99qCcYT1SbTseE8EsT") }; Total (peer): 0.
[2023-05-03T11:35:21Z DEBUG libp2p_gossipsub::behaviour] Peer disconnected: 12D3KooWEcodQSPbhaTTF9v9RSmQUTf4UY99qCcYT1SbTseE8EsT
[2023-05-03T11:35:21Z INFO  jiri_core::p2p] Unrecognized event received: JiriBehaviourEvent: OutboundFailure { peer: PeerId("12D3KooWEcodQSPbhaTTF9v9RSmQUTf4UY99qCcYT1SbTseE8EsT"), request_id: RequestId(1), error: ConnectionClosed }
```
I asked about this error to the maintainer of the `libp2p-websys-transport` maintainer: https://github.com/vincev/libp2p-websys-transport/issues/8, but it seems that I have to dig it more.